### PR TITLE
[WEBSITE-689] Updating queries to allow current/historical disambiguation

### DIFF
--- a/app/controllers/concerns/response_stream_helper.rb
+++ b/app/controllers/concerns/response_stream_helper.rb
@@ -1,12 +1,13 @@
 require 'net/http'
 
 module ResponseStreamHelper
-  def response_streamer(uri)
+  def response_streamer(query)
     response.content_type = 'application/n-triples'
 
-    Net::HTTP.start(uri.host) do |client|
-      request = Net::HTTP::Get.new uri
+    Net::HTTP.start(URI(DATA_ENDPOINT).host) do |client|
+      request = Net::HTTP::Post.new(URI(DATA_ENDPOINT))
 
+      request.set_form_data('query' => query)
       request.add_field('Accept', 'application/n-triples')
 
       client.request(request) do |turtle_response|

--- a/app/controllers/constituencies_controller.rb
+++ b/app/controllers/constituencies_controller.rb
@@ -1,72 +1,70 @@
 class ConstituenciesController < ApplicationController
   def index
-    uri = ConstituencyQueryObject.all
-    response_streamer(uri)
+    query = ConstituencyQueryObject.all
+    response_streamer(query)
   end
 
   def lookup
     source = params['source']
     id = params['id']
-    uri = ConstituencyQueryObject.lookup(source, id)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.lookup(source, id)
+    response_streamer(query)
   end
 
   def show
     constituency_id = params[:constituency]
-    uri = ConstituencyQueryObject.find(constituency_id)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.find(constituency_id)
+    response_streamer(query)
   end
 
-
-
   def current
-    uri = ConstituencyQueryObject.all_current
-    response_streamer(uri)
+    query = ConstituencyQueryObject.all_current
+    response_streamer(query)
   end
 
   def members
     constituency_id = params[:constituency_id]
-    uri = ConstituencyQueryObject.members(constituency_id)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.members(constituency_id)
+    response_streamer(query)
   end
 
   def current_member
     constituency_id = params[:constituency_id]
-    uri = ConstituencyQueryObject.current_member(constituency_id)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.current_member(constituency_id)
+    response_streamer(query)
   end
 
   def contact_point
     constituency_id = params[:constituency_id]
-    uri = ConstituencyQueryObject.contact_point(constituency_id)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.contact_point(constituency_id)
+    response_streamer(query)
   end
 
   def letters
     letter = params[:letter]
-    uri = ConstituencyQueryObject.all_by_letter(letter)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.all_by_letter(letter)
+    response_streamer(query)
   end
 
   def a_z_letters
-    uri = ConstituencyQueryObject.a_z_letters
-    response_streamer(uri)
+    query = ConstituencyQueryObject.a_z_letters
+    response_streamer(query)
   end
 
   def current_letters
     letter = params[:letter]
-    uri = ConstituencyQueryObject.all_current_by_letter(letter)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.all_current_by_letter(letter)
+    response_streamer(query)
   end
 
   def a_z_letters_current
-    uri = ConstituencyQueryObject.a_z_letters_current
-    response_streamer(uri)
+    query = ConstituencyQueryObject.a_z_letters_current
+    response_streamer(query)
   end
 
   def lookup_by_letters
     letters = params[:letters]
-    uri = ConstituencyQueryObject.lookup_by_letters(letters)
-    response_streamer(uri)
+    query = ConstituencyQueryObject.lookup_by_letters(letters)
+    response_streamer(query)
   end
 end

--- a/app/controllers/contact_points_controller.rb
+++ b/app/controllers/contact_points_controller.rb
@@ -1,13 +1,13 @@
 class ContactPointsController < ApplicationController
   def index
-    uri = ContactPointQueryObject.all
-    response_streamer(uri)
+    query = ContactPointQueryObject.all
+    response_streamer(query)
   end
 
   def show
     id = params[:id]
-    uri = ContactPointQueryObject.find(id)
-    response_streamer(uri)
+    query = ContactPointQueryObject.find(id)
+    response_streamer(query)
   end
 
 

--- a/app/controllers/houses_controller.rb
+++ b/app/controllers/houses_controller.rb
@@ -1,126 +1,126 @@
 class HousesController < ApplicationController
   def index
-    uri = HouseQueryObject.all
-    response_streamer(uri)
+    query = HouseQueryObject.all
+    response_streamer(query)
   end
 
   def lookup
     source = params['source']
     id = params['id']
-    uri = HouseQueryObject.lookup(source, id)
-    response_streamer(uri)
+    query = HouseQueryObject.lookup(source, id)
+    response_streamer(query)
   end
 
   def show
     id = params[:house]
-    uri = HouseQueryObject.find(id)
-    response_streamer(uri)
+    query = HouseQueryObject.find(id)
+    response_streamer(query)
   end
 
   def members
     id = params[:house_id]
-    uri = HouseQueryObject.members(id)
-    response_streamer(uri)
+    query = HouseQueryObject.members(id)
+    response_streamer(query)
   end
 
   def current_members
     id = params[:house_id]
-    uri = HouseQueryObject.current_members(id)
-    response_streamer(uri)
+    query = HouseQueryObject.current_members(id)
+    response_streamer(query)
   end
 
   def parties
     id = params[:house_id]
-    uri = HouseQueryObject.parties(id)
-    response_streamer(uri)
+    query = HouseQueryObject.parties(id)
+    response_streamer(query)
   end
 
   def current_parties
     id = params[:house_id]
-    uri = HouseQueryObject.current_parties(id)
-    response_streamer(uri)
+    query = HouseQueryObject.current_parties(id)
+    response_streamer(query)
   end
 
   def members_letters
     letter = params[:letter]
     id = params[:house_id]
-    uri = HouseQueryObject.members_by_letter(id, letter)
-    response_streamer(uri)
+    query = HouseQueryObject.members_by_letter(id, letter)
+    response_streamer(query)
   end
 
   def a_z_letters_members
     id = params[:house_id]
-    uri = HouseQueryObject.a_z_letters_members(id)
-    response_streamer(uri)
+    query = HouseQueryObject.a_z_letters_members(id)
+    response_streamer(query)
   end
 
   def current_members_letters
     letter = params[:letter]
     id = params[:house_id]
-    uri = HouseQueryObject.current_members_by_letter(id, letter)
-    response_streamer(uri)
+    query = HouseQueryObject.current_members_by_letter(id, letter)
+    response_streamer(query)
   end
 
   def a_z_letters_members_current
     id = params[:house_id]
-    uri = HouseQueryObject.a_z_letters_members_current(id)
-    response_streamer(uri)
+    query = HouseQueryObject.a_z_letters_members_current(id)
+    response_streamer(query)
   end
 
   def party
     house_id = params[:house_id]
     party_id = params[:party_id]
-    uri = HouseQueryObject.party(house_id, party_id)
-    response_streamer(uri)
+    query = HouseQueryObject.party(house_id, party_id)
+    response_streamer(query)
   end
 
   def party_members
     house_id = params[:house_id]
     party_id = params[:party_id]
-    uri = HouseQueryObject.party_members(house_id, party_id)
-    response_streamer(uri)
+    query = HouseQueryObject.party_members(house_id, party_id)
+    response_streamer(query)
   end
 
   def party_members_letters
     house_id = params[:house_id]
     party_id = params[:party_id]
     letter = params[:letter]
-    uri = HouseQueryObject.party_members_letters(house_id, party_id, letter)
-    response_streamer(uri)
+    query = HouseQueryObject.party_members_letters(house_id, party_id, letter)
+    response_streamer(query)
   end
 
   def a_z_letters_party_members
     house_id = params[:house_id]
     party_id = params[:party_id]
-    uri = HouseQueryObject.a_z_letters_party_members(house_id, party_id)
-    response_streamer(uri)
+    query = HouseQueryObject.a_z_letters_party_members(house_id, party_id)
+    response_streamer(query)
   end
 
   def current_party_members
     house_id = params[:house_id]
     party_id = params[:party_id]
-    uri = HouseQueryObject.current_party_members(house_id, party_id)
-    response_streamer(uri)
+    query = HouseQueryObject.current_party_members(house_id, party_id)
+    response_streamer(query)
   end
 
   def current_party_members_letters
     house_id = params[:house_id]
     party_id = params[:party_id]
     letter = params[:letter]
-    uri = HouseQueryObject.current_party_members_letters(house_id, party_id, letter)
-    response_streamer(uri)
+    query = HouseQueryObject.current_party_members_letters(house_id, party_id, letter)
+    response_streamer(query)
   end
 
   def a_z_letters_party_members_current
     house_id = params[:house_id]
     party_id = params[:party_id]
-    uri = HouseQueryObject.a_z_letters_party_members_current(house_id, party_id)
-    response_streamer(uri)
+    query = HouseQueryObject.a_z_letters_party_members_current(house_id, party_id)
+    response_streamer(query)
   end
 
   def lookup_by_letters
     letters = params[:letters]
-    uri = HouseQueryObject.lookup_by_letters(letters)
-    response_streamer(uri)
+    query = HouseQueryObject.lookup_by_letters(letters)
+    response_streamer(query)
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,33 +1,33 @@
 class MembersController < ApplicationController
   def index
-    uri = MemberQueryObject.all
-    response_streamer(uri)
+    query = MemberQueryObject.all
+    response_streamer(query)
   end
 
   def current
-    uri = MemberQueryObject.all_current
-    response_streamer(uri)
+    query = MemberQueryObject.all_current
+    response_streamer(query)
   end
 
   def letters
     letter = params[:letter]
-    uri = MemberQueryObject.all_by_letter(letter)
-    response_streamer(uri)
+    query = MemberQueryObject.all_by_letter(letter)
+    response_streamer(query)
   end
 
   def a_z_letters
-    uri = MemberQueryObject.a_z_letters
-    response_streamer(uri)
+    query = MemberQueryObject.a_z_letters
+    response_streamer(query)
   end
 
   def current_letters
     letter = params[:letter]
-    uri = MemberQueryObject.all_current_by_letter(letter)
-    response_streamer(uri)
+    query = MemberQueryObject.all_current_by_letter(letter)
+    response_streamer(query)
   end
 
   def a_z_letters_current
-    uri = MemberQueryObject.a_z_letters_current
-    response_streamer(uri)
+    query = MemberQueryObject.a_z_letters_current
+    response_streamer(query)
   end
 end

--- a/app/controllers/parties_controller.rb
+++ b/app/controllers/parties_controller.rb
@@ -1,84 +1,84 @@
 class PartiesController < ApplicationController
   def index
-    uri = PartyQueryObject.all
-    response_streamer(uri)
+    query = PartyQueryObject.all
+    response_streamer(query)
   end
 
   def lookup
     source = params['source']
     id = params['id']
-    uri = PartyQueryObject.lookup(source, id)
-    response_streamer(uri)
+    query = PartyQueryObject.lookup(source, id)
+    response_streamer(query)
   end
 
   def a_z_letters_all
-    uri = PartyQueryObject.a_z_letters_all
-    response_streamer(uri)
+    query = PartyQueryObject.a_z_letters_all
+    response_streamer(query)
   end
 
   def current
-    uri = PartyQueryObject.all_current
-    response_streamer(uri)
+    query = PartyQueryObject.all_current
+    response_streamer(query)
   end
 
   def a_z_letters_current
-    uri = PartyQueryObject.a_z_letters_current
-    response_streamer(uri)
+    query = PartyQueryObject.a_z_letters_current
+    response_streamer(query)
   end
 
   def show
     id = params[:party]
-    uri = PartyQueryObject.find(id)
-    response_streamer(uri)
+    query = PartyQueryObject.find(id)
+    response_streamer(query)
   end
 
   def members
     id = params[:party_id]
-    uri = PartyQueryObject.members(id)
-    response_streamer(uri)
+    query = PartyQueryObject.members(id)
+    response_streamer(query)
   end
 
   def current_members
     id = params[:party_id]
-    uri = PartyQueryObject.current_members(id)
-    response_streamer(uri)
+    query = PartyQueryObject.current_members(id)
+    response_streamer(query)
   end
 
   def letters
     letter = params[:letter]
-    uri = PartyQueryObject.all_by_letter(letter)
-    response_streamer(uri)
+    query = PartyQueryObject.all_by_letter(letter)
+    response_streamer(query)
   end
 
   def members_letters
     letter = params[:letter]
     id = params[:party_id]
-    uri = PartyQueryObject.members_by_letter(id, letter)
-    response_streamer(uri)
+    query = PartyQueryObject.members_by_letter(id, letter)
+    response_streamer(query)
   end
 
   def a_z_letters_members
     id = params[:party_id]
-    uri = PartyQueryObject.a_z_letters_members(id)
-    response_streamer(uri)
+    query = PartyQueryObject.a_z_letters_members(id)
+    response_streamer(query)
   end
 
   def current_members_letters
     letter = params[:letter]
     id = params[:party_id]
-    uri = PartyQueryObject.current_members_by_letter(id, letter)
-    response_streamer(uri)
+    query = PartyQueryObject.current_members_by_letter(id, letter)
+    response_streamer(query)
   end
 
   def a_z_letters_members_current
     id = params[:party_id]
-    uri = PartyQueryObject.a_z_letters_members_current(id)
-    response_streamer(uri)
+    query = PartyQueryObject.a_z_letters_members_current(id)
+    response_streamer(query)
   end
 
   def lookup_by_letters
     letters = params[:letters]
-    uri = PartyQueryObject.lookup_by_letters(letters)
-    response_streamer(uri)
+    query = PartyQueryObject.lookup_by_letters(letters)
+    response_streamer(query)
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -3,79 +3,79 @@ require 'uri'
 
 class PeopleController < ApplicationController
   def index
-    uri = PersonQueryObject.all
-    response_streamer(uri)
+    query = PersonQueryObject.all
+    response_streamer(query)
   end
 
   def lookup
     source = params['source']
     id = params['id']
-    uri = PersonQueryObject.lookup(source, id)
-    response_streamer(uri)
+    query = PersonQueryObject.lookup(source, id)
+    response_streamer(query)
   end
 
   def a_z_letters
-    uri = PersonQueryObject.a_z_letters
-    response_streamer(uri)
+    query = PersonQueryObject.a_z_letters
+    response_streamer(query)
   end
 
   def show
     id = params[:person]
-    uri = PersonQueryObject.find(id)
-    response_streamer(uri)
+    query = PersonQueryObject.find(id)
+    response_streamer(query)
   end
 
   def constituencies
     person_id = params[:person_id]
-    uri = PersonQueryObject.constituencies(person_id)
-    response_streamer(uri)
+    query = PersonQueryObject.constituencies(person_id)
+    response_streamer(query)
   end
 
   def current_constituency
     person_id = params[:person_id]
-    uri = PersonQueryObject.current_constituency(person_id)
-    response_streamer(uri)
+    query = PersonQueryObject.current_constituency(person_id)
+    response_streamer(query)
   end
 
   def parties
     person_id = params[:person_id]
-    uri = PersonQueryObject.parties(person_id)
-    response_streamer(uri)
+    query = PersonQueryObject.parties(person_id)
+    response_streamer(query)
   end
 
   def current_party
     person_id = params[:person_id]
-    uri = PersonQueryObject.current_party(person_id)
-    response_streamer(uri)
+    query = PersonQueryObject.current_party(person_id)
+    response_streamer(query)
   end
 
   def contact_points
     person_id = params[:person_id]
-    uri = PersonQueryObject.contact_points(person_id)
-    response_streamer(uri)
+    query = PersonQueryObject.contact_points(person_id)
+    response_streamer(query)
   end
 
   def houses
     person_id = params[:person_id]
-    uri = PersonQueryObject.houses(person_id)
-    response_streamer(uri)
+    query = PersonQueryObject.houses(person_id)
+    response_streamer(query)
   end
 
   def current_house
     person_id = params[:person_id]
-    uri = PersonQueryObject.current_house(person_id)
-    response_streamer(uri)
+    query = PersonQueryObject.current_house(person_id)
+    response_streamer(query)
   end
 
   def letters
     letter = params[:letter]
-    uri = PersonQueryObject.all_by_letter(letter)
-    response_streamer(uri)
+    query = PersonQueryObject.all_by_letter(letter)
+    response_streamer(query)
   end
 
   def lookup_by_letters
     letters = params[:letters]
-    uri = PersonQueryObject.lookup_by_letters(letters)
-    response_streamer(uri)
+    query = PersonQueryObject.lookup_by_letters(letters)
+    response_streamer(query)
   end
 end

--- a/app/models/constituency_query_object.rb
+++ b/app/models/constituency_query_object.rb
@@ -122,12 +122,29 @@ class ConstituencyQueryObject
      CONSTRUCT{
           ?constituencyGroup
               a parl:ConstituencyGroup ;
-              parl:constituencyGroupName ?name .
+              parl:constituencyGroupName ?name ;
+        	  parl:constituencyGroupHasHouseSeat ?seat .
+    	  ?seat
+        	a parl:HouseSeat ;
+        	parl:houseSeatHasSeatIncumbency ?seatIncumbency .
+    	  ?seatIncumbency
+        	a parl:SeatIncumbency ;
+        	parl:incumbencyHasMember ?member .
+    	  ?member
+        	a parl:Person ;
+        	parl:personGivenName ?givenName ;
+        	parl:personFamilyName ?familyName .
       }
       WHERE {
           ?constituencyGroup a parl:ConstituencyGroup .
           FILTER NOT EXISTS { ?constituencyGroup a parl:PastConstituencyGroup . }
           OPTIONAL { ?constituencyGroup parl:constituencyGroupName ?name . }
+    	    ?constituencyGroup parl:constituencyGroupHasHouseSeat ?seat .
+    	    ?seat parl:houseSeatHasSeatIncumbency ?seatIncumbency .
+    	    FILTER NOT EXISTS { ?seatIncumbency a parl:PastIncumbency . }
+    	    ?seatIncumbency parl:incumbencyHasMember ?member .
+    	    OPTIONAL { ?member parl:personGivenName ?givenName . }
+          OPTIONAL { ?member parl:personFamilyName ?familyName . }
       }'
   end
 
@@ -136,12 +153,30 @@ class ConstituencyQueryObject
      CONSTRUCT{
           ?constituencyGroup
               a parl:ConstituencyGroup ;
-              parl:constituencyGroupName ?name .
+              parl:constituencyGroupName ?name ;
+        	    parl:constituencyGroupHasHouseSeat ?seat .
+    	  ?seat
+        	a parl:HouseSeat ;
+        	parl:houseSeatHasSeatIncumbency ?seatIncumbency .
+    	  ?seatIncumbency
+        	a parl:SeatIncumbency ;
+        	parl:incumbencyHasMember ?member .
+    	  ?member
+        	a parl:Person ;
+        	parl:personGivenName ?givenName ;
+        	parl:personFamilyName ?familyName .
       }
       WHERE {
           ?constituencyGroup a parl:ConstituencyGroup .
           FILTER NOT EXISTS { ?constituencyGroup a parl:PastConstituencyGroup . }
           OPTIONAL { ?constituencyGroup parl:constituencyGroupName ?name . }
+    	    ?constituencyGroup parl:constituencyGroupHasHouseSeat ?seat .
+    	    ?seat parl:houseSeatHasSeatIncumbency ?seatIncumbency .
+    	    FILTER NOT EXISTS { ?seatIncumbency a parl:PastIncumbency . }
+    	    ?seatIncumbency parl:incumbencyHasMember ?member .
+    	    OPTIONAL { ?member parl:personGivenName ?givenName . }
+          OPTIONAL { ?member parl:personFamilyName ?familyName . }
+
     		  FILTER regex(str(?name), \"^#{letter}\", 'i') .
       }"
   end

--- a/app/models/constituency_query_object.rb
+++ b/app/models/constituency_query_object.rb
@@ -2,42 +2,41 @@ class ConstituencyQueryObject
   extend QueryObject
 
   def self.all
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT{
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT{
           ?constituencyGroup
             a parl:ConstituencyGroup ;
-            parl:constituencyGroupName ?name .
+            parl:constituencyGroupName ?name ;
+            parl:constituencyGroupEndDate ?endDate .
       }
       WHERE {
       	?constituencyGroup a parl:ConstituencyGroup .
           OPTIONAL { ?constituencyGroup parl:constituencyGroupName ?name . }
-      }
-    ')
+          OPTIONAL { ?constituencyGroup parl:constituencyGroupEndDate ?endDate . }
+
+      }'
   end
 
   def self.all_by_letter(letter)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT{
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT{
           ?constituencyGroup
               a parl:ConstituencyGroup ;
-              parl:constituencyGroupName ?name .
+              parl:constituencyGroupName ?name ;
+              parl:constituencyGroupEndDate ?endDate .
       }
       WHERE {
           ?constituencyGroup a parl:ConstituencyGroup .
           OPTIONAL { ?constituencyGroup parl:constituencyGroupName ?name . }
+          OPTIONAL { ?constituencyGroup parl:constituencyGroupEndDate ?endDate . }
+
     		  FILTER regex(str(?name), \"^#{letter}\", 'i') .
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -47,15 +46,12 @@ class ConstituencyQueryObject
 
           BIND(ucase(SUBSTR(?constituencyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ')
+      }'
   end
 
   def self.lookup(source, id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?constituency
            a parl:ConstituencyGroup .
       }
@@ -65,14 +61,12 @@ class ConstituencyQueryObject
 
 	      ?constituency a parl:ConstituencyGroup .
         ?constituency ?source ?id .
-      }")
+      }"
   end
 
   def self.find(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT{
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT{
           ?constituencyGroup
             a parl:ConstituencyGroup ;
             parl:constituencyGroupEndDate ?endDate ;
@@ -120,15 +114,12 @@ class ConstituencyQueryObject
             OPTIONAL { ?member parl:personGivenName ?givenName . }
             OPTIONAL { ?member parl:personFamilyName ?familyName . }
           }
-      }
-    ")
+      }"
   end
 
   def self.all_current
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT{
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT{
           ?constituencyGroup
               a parl:ConstituencyGroup ;
               parl:constituencyGroupName ?name .
@@ -137,15 +128,12 @@ class ConstituencyQueryObject
           ?constituencyGroup a parl:ConstituencyGroup .
           FILTER NOT EXISTS { ?constituencyGroup a parl:PastConstituencyGroup . }
           OPTIONAL { ?constituencyGroup parl:constituencyGroupName ?name . }
-      }
-    ')
+      }'
   end
 
   def self.all_current_by_letter(letter)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT{
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT{
           ?constituencyGroup
               a parl:ConstituencyGroup ;
               parl:constituencyGroupName ?name .
@@ -155,14 +143,12 @@ class ConstituencyQueryObject
           FILTER NOT EXISTS { ?constituencyGroup a parl:PastConstituencyGroup . }
           OPTIONAL { ?constituencyGroup parl:constituencyGroupName ?name . }
     		  FILTER regex(str(?name), \"^#{letter}\", 'i') .
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters_current
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -173,15 +159,12 @@ class ConstituencyQueryObject
 
           BIND(ucase(SUBSTR(?constituencyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ')
+      }'
   end
 
   def self.members(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT{
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT{
     	   	?constituencyGroup
             a parl:ConstituencyGroup ;
          		parl:constituencyGroupName ?name ;
@@ -214,15 +197,12 @@ class ConstituencyQueryObject
         	    OPTIONAL { ?member parl:personFamilyName ?familyName . }
           }
         }
-      }
-    ")
+      }"
   end
 
   def self.current_member(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT{
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT{
     	   	?constituencyGroup
             	a parl:ConstituencyGroup ;
          		  parl:constituencyGroupName ?name ;
@@ -254,14 +234,12 @@ class ConstituencyQueryObject
         	  OPTIONAL { ?member parl:personFamilyName ?familyName . }
           }
         }
-      }
-    ")
+      }"
   end
 
   def self.contact_point(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
       	?constituencyGroup a parl:ConstituencyGroup ;
         				parl:constituencyGroupHasHouseSeat ?houseSeat ;
         				parl:constituencyGroupName ?name .
@@ -308,14 +286,12 @@ class ConstituencyQueryObject
         		}
     		}
         OPTIONAL { ?constituencyGroup parl:constituencyGroupName ?name . }
-      }
-    ")
+      }"
   end
 
   def self.lookup_by_letters(letters)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?constituency
         	a parl:ConstituencyGroup ;
          	parl:constituencyGroupName ?constituencyName .
@@ -325,7 +301,6 @@ class ConstituencyQueryObject
         ?constituency parl:constituencyGroupName ?constituencyName .
 
     	  FILTER(regex(str(?constituencyName), \"#{letters}\", 'i')) .
-      }
-    ")
+      }"
   end
 end

--- a/app/models/contact_point_query_object.rb
+++ b/app/models/contact_point_query_object.rb
@@ -2,9 +2,8 @@ class ContactPointQueryObject
   extend QueryObject
 
   def self.all
-    self.uri_builder('
-        PREFIX parl: <http://id.ukpds.org/schema/>
-        CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
            ?contactPoint
                a parl:ContactPoint ;
                parl:email ?email ;
@@ -34,13 +33,11 @@ class ContactPointQueryObject
                	OPTIONAL{ ?postalAddress parl:addressLine5 ?addressLine5 . }
           	}
       }'
-    )
   end
 
   def self.find(id)
-    self.uri_builder("
-        PREFIX parl: <http://id.ukpds.org/schema/>
-        CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
            ?contactPoint
                a parl:ContactPoint ;
                parl:email ?email ;
@@ -85,9 +82,6 @@ class ContactPointQueryObject
         		  OPTIONAL { ?person parl:personFamilyName ?familyName . }
         		  OPTIONAL { ?person parl:personGivenName ?givenName . }
             }
-      }
-    ")
+      }"
   end
-
-
 end

--- a/app/models/house_query_object.rb
+++ b/app/models/house_query_object.rb
@@ -2,10 +2,8 @@ class HouseQueryObject
   extend QueryObject
 
   def self.all
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
           ?house
             a parl:House ;
         	  parl:houseName ?houseName .
@@ -15,14 +13,11 @@ class HouseQueryObject
              a parl:House ;
     			   parl:houseName ?houseName .
       }'
-    )
   end
 
   def self.lookup(source, id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?house
            a parl:House .
       }
@@ -32,14 +27,12 @@ class HouseQueryObject
 
 	      ?house a parl:House .
         ?house ?source ?id .
-      }")
+      }"
   end
 
   def self.find(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
           ?house
             a parl:House ;
             parl:houseName ?houseName .
@@ -50,13 +43,12 @@ class HouseQueryObject
           ?house
             a parl:House ;
             parl:houseName ?houseName .
-      }")
+      }"
   end
 
   def self.members(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	  a parl:Person ;
             parl:personGivenName ?givenName ;
@@ -90,14 +82,12 @@ class HouseQueryObject
           	?incumbency parl:seatIncumbencyHasHouseSeat ?seat .
           	?seat parl:houseSeatHasHouse ?house .
     	  }
-      }
-    ")
+      }"
   end
 
   def self.members_by_letter(id, letter)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	  a parl:Person ;
             parl:personGivenName ?givenName ;
@@ -133,14 +123,12 @@ class HouseQueryObject
     	  }
 
         FILTER regex(str(?familyName), \"^#{letter}\", 'i') .
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters_members(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -163,15 +151,12 @@ class HouseQueryObject
 
         BIND(ucase(SUBSTR(?familyName, 1, 1)) as ?firstLetter)
         }
-      }
-
-    ")
+      }"
   end
 
   def self.current_members(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	  a parl:Person ;
             parl:personGivenName ?givenName ;
@@ -231,14 +216,12 @@ class HouseQueryObject
 
         OPTIONAL { ?person parl:personGivenName ?givenName . }
         OPTIONAL { ?person parl:personFamilyName ?familyName . }
-      }
-    ")
+      }"
   end
 
   def self.current_members_by_letter(id, letter)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	  a parl:Person ;
             parl:personGivenName ?givenName ;
@@ -300,14 +283,12 @@ class HouseQueryObject
         OPTIONAL { ?person parl:personFamilyName ?familyName . }
 
         FILTER regex(str(?familyName), \"^#{letter}\", 'i') .
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters_members_current(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -331,14 +312,12 @@ class HouseQueryObject
 
           BIND(ucase(SUBSTR(?familyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ")
+      }"
   end
 
   def self.parties(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?house
         	a parl:House ;
         	parl:houseName ?houseName .
@@ -364,14 +343,12 @@ class HouseQueryObject
             		?incumbency parl:seatIncumbencyHasHouseSeat ?seat .
             		?seat parl:houseSeatHasHouse ?house .
     		    }
-         }
-    ")
+         }"
   end
 
   def self.current_parties(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?house
         	a parl:House ;
         	parl:houseName ?houseName .
@@ -405,15 +382,12 @@ class HouseQueryObject
     		  }
         }
         GROUP BY ?party ?house ?houseName ?partyName
-      }
-    ")
+      }"
   end
 
   def self.party(house_id, party_id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
           ?house
             a parl:House ;
             parl:houseName ?houseName .
@@ -444,14 +418,12 @@ class HouseQueryObject
               	?seat parl:houseSeatHasHouse ?house .
     	      }
           }
-      }
-   ")
+      }"
   end
 
   def self.party_members(house_id, party_id)
-    self.uri_builder("
-	    PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
     	?person
         	a parl:Person ;
         	parl:personGivenName ?givenName ;
@@ -504,13 +476,11 @@ class HouseQueryObject
         			?seat parl:houseSeatHasHouse ?house .
     			}
         }
-      }
-    ")
+      }"
   end
 
   def self.party_members_letters(house_id, party_id, letter)
-    self.uri_builder("
-	    PREFIX parl: <http://id.ukpds.org/schema/>
+    "PREFIX parl: <http://id.ukpds.org/schema/>
       CONSTRUCT {
     	?person
         	a parl:Person ;
@@ -565,14 +535,12 @@ class HouseQueryObject
     			}
           FILTER regex(str(?familyName), \"^#{letter}\", 'i') .
         }
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters_party_members(house_id, party_id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -597,14 +565,12 @@ class HouseQueryObject
 
           BIND(ucase(SUBSTR(?familyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ")
+      }"
   end
 
   def self.current_party_members(house_id, party_id)
-    self.uri_builder("
-	    PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
     	?person
         	a parl:Person ;
         	parl:personGivenName ?givenName ;
@@ -656,13 +622,11 @@ class HouseQueryObject
         			?seat parl:houseSeatHasHouse ?house .
     			}
         }
-      }
-    ")
+      }"
   end
 
   def self.current_party_members_letters(house_id, party_id, letter)
-    self.uri_builder("
-	    PREFIX parl: <http://id.ukpds.org/schema/>
+    "PREFIX parl: <http://id.ukpds.org/schema/>
       CONSTRUCT {
     	?person
         	a parl:Person ;
@@ -716,14 +680,12 @@ class HouseQueryObject
     			}
         }
         FILTER regex(str(?familyName), \"^#{letter}\", 'i') .
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters_party_members_current(house_id, party_id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -750,14 +712,12 @@ class HouseQueryObject
 
           BIND(ucase(SUBSTR(?familyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ")
+      }"
   end
 
   def self.lookup_by_letters(letters)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?house
         	a parl:House ;
          	parl:houseName ?houseName .
@@ -767,7 +727,6 @@ class HouseQueryObject
         ?house parl:houseName ?houseName .
 
     	  FILTER(regex(str(?houseName), \"#{letters}\", 'i')) .
-      }
-    ")
+      }"
   end
 end

--- a/app/models/member_query_object.rb
+++ b/app/models/member_query_object.rb
@@ -13,7 +13,7 @@ class MemberQueryObject
          a parl:Person ;
          parl:personGivenName ?givenName ;
          parl:personFamilyName ?familyName ;
-         parl:memberHasIncumbency ?seatIncumbency ;
+         parl:memberHasIncumbency ?incumbency ;
          parl:partyMemberHasPartyMembership ?partyMembership .
         ?seatIncumbency
          a parl:SeatIncumbency ;
@@ -22,7 +22,9 @@ class MemberQueryObject
          parl:incumbencyEndDate ?seatIncumbencyEndDate .
     	  ?houseIncumbency
          a parl:HouseIncumbency ;
-         parl:houseIncumbencyHasHouse ?house .
+         parl:houseIncumbencyHasHouse ?house ;
+         parl:incumbencyStartDate ?seatIncumbencyStartDate ;
+         parl:incumbencyEndDate ?seatIncumbencyEndDate .
         ?house
          a parl:House ;
          parl:houseName ?houseName .
@@ -44,21 +46,23 @@ class MemberQueryObject
           OPTIONAL { ?person parl:personGivenName ?givenName . }
           OPTIONAL { ?person parl:personFamilyName ?familyName . }
            { ?incumbency a parl:HouseIncumbency .
-                 BIND(?incumbency AS ?houseIncumbency)
-               ?houseIncumbency parl:houseIncumbencyHasHouse ?house .
-                ?house parl:houseName ?houseName .
+              BIND(?incumbency AS ?houseIncumbency)
+              ?houseIncumbency parl:houseIncumbencyHasHouse ?house .
+              ?house parl:houseName ?houseName .
+              ?houseIncumbency parl:incumbencyStartDate ?houseIncumbencyStartDate .
+              OPTIONAL { ?houseIncumbency parl:incumbencyEndDate ?houseIncumbencyEndDate . }
    		      }
            UNION {
-   ?incumbency a parl:SeatIncumbency .
-          BIND(?incumbency AS ?seatIncumbency)
-          ?seatIncumbency parl:seatIncumbencyHasHouseSeat ?houseSeat .
-          ?seatIncumbency parl:incumbencyStartDate ?seatIncumbencyStartDate .
-         OPTIONAL { ?seatIncumbency parl:incumbencyEndDate ?seatIncumbencyEndDate . }
-        			?houseSeat parl:houseSeatHasHouse ?house .
-                     ?house parl:houseName ?houseName .
-    				OPTIONAL {?houseSeat parl:houseSeatHasConstituencyGroup ?constituencyGroup .
+            ?incumbency a parl:SeatIncumbency .
+            BIND(?incumbency AS ?seatIncumbency)
+            ?seatIncumbency parl:seatIncumbencyHasHouseSeat ?houseSeat .
+            ?seatIncumbency parl:incumbencyStartDate ?seatIncumbencyStartDate .
+            OPTIONAL { ?seatIncumbency parl:incumbencyEndDate ?seatIncumbencyEndDate . }
+        		?houseSeat parl:houseSeatHasHouse ?house .
+            ?house parl:houseName ?houseName .
+    				OPTIONAL { ?houseSeat parl:houseSeatHasConstituencyGroup ?constituencyGroup .
         					?constituencyGroup parl:constituencyGroupName ?constituencyName . }
-   				}
+   				  }
 
     	 ?person parl:partyMemberHasPartyMembership ?partyMembership .
          ?partyMembership parl:partyMembershipHasParty ?party .

--- a/app/models/party_query_object.rb
+++ b/app/models/party_query_object.rb
@@ -2,10 +2,8 @@ class PartyQueryObject
   extend QueryObject
 
   def self.all
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party
            a parl:Party ;
            parl:partyName ?partyName .
@@ -15,15 +13,12 @@ class PartyQueryObject
           a parl:Party ;
           parl:partyHasPartyMembership ?partyMembership ;
           parl:partyName ?partyName .
-      }
-    ')
+      }'
   end
 
   def self.lookup(source, id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party
            a parl:Party .
       }
@@ -33,13 +28,12 @@ class PartyQueryObject
 
 	      ?party a parl:Party .
         ?party ?source ?id .
-      }")
+      }"
   end
 
   def self.all_current
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party
               a parl:Party ;
             	parl:partyName ?partyName .
@@ -52,14 +46,12 @@ class PartyQueryObject
         FILTER NOT EXISTS { ?partyMembership a parl:PastPartyMembership . }
         ?partyMembership parl:partyMembershipHasParty ?party .
         ?party parl:partyName ?partyName .
-      }
-    ')
+      }'
   end
 
   def self.a_z_letters_current
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -74,8 +66,7 @@ class PartyQueryObject
 
           BIND(ucase(SUBSTR(?partyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ')
+      }'
   end
 
   def self.all_by_letter(letter)
@@ -97,9 +88,8 @@ class PartyQueryObject
   end
 
   def self.a_z_letters_all
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -110,29 +100,37 @@ class PartyQueryObject
 
           BIND(ucase(SUBSTR(?partyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ')
+      }'
   end
 
   def self.find(id)
-    self.uri_builder("
-     PREFIX parl: <http://id.ukpds.org/schema/>
+    "PREFIX parl: <http://id.ukpds.org/schema/>
      CONSTRUCT {
-	      ?party a parl:Party;
-               parl:partyName ?name
+	      ?party a parl:Party ;
+               parl:partyName ?name ;
+               parl:count ?memberCount .
      }
-     WHERE {
-        BIND(<#{DATA_URI_PREFIX}/#{id}> AS ?party)
+      WHERE {
+    	  SELECT ?party ?name (COUNT(?member) AS ?memberCount)
+		    WHERE {
+          BIND(<#{DATA_URI_PREFIX}/#{id}> AS ?party)
 
-	      ?party parl:partyName ?name
-      }
-    ")
+	        ?party parl:partyName ?name .
+          OPTIONAL {
+          	?party parl:partyHasPartyMembership ?partyMembership .
+    	  	  FILTER NOT EXISTS { ?partyMembership a parl:PastPartyMembership . }
+    	  	  ?partyMembership parl:partyMembershipHasPartyMember ?member .
+    	  	  ?member parl:memberHasIncumbency ?incumbency .
+    	  	  FILTER NOT EXISTS { ?incumbency a parl:PastIncumbency . }
+          }
+        }
+      GROUP BY ?party ?name
+    }"
   end
 
   def self.members(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party a parl:Party ;
             parl:partyName ?partyName .
         ?person a parl:Person ;
@@ -157,14 +155,12 @@ class PartyQueryObject
           OPTIONAL { ?person parl:personGivenName ?givenName . }
           OPTIONAL { ?person parl:personFamilyName ?familyName . }
         }
-      }
-    ")
+      }"
   end
 
   def self.members_by_letter(id, letter)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party a parl:Party ;
             parl:partyName ?partyName .
         ?person a parl:Person ;
@@ -190,14 +186,12 @@ class PartyQueryObject
 
           FILTER regex(str(?familyName), \"^#{letter}\", 'i') .
         }
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters_members(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -210,14 +204,12 @@ class PartyQueryObject
 
           BIND(ucase(SUBSTR(?familyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ")
+      }"
   end
 
   def self.current_members(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party a parl:Party ;
             parl:partyName ?partyName .
         ?person a parl:Person ;
@@ -243,14 +235,12 @@ class PartyQueryObject
           OPTIONAL { ?person parl:personGivenName ?givenName . }
           OPTIONAL { ?person parl:personFamilyName ?familyName . }
         }
-      }
-      ")
+      }"
   end
 
   def self.current_members_by_letter(id, letter)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party a parl:Party ;
             parl:partyName ?partyName .
         ?person a parl:Person ;
@@ -277,14 +267,12 @@ class PartyQueryObject
           OPTIONAL { ?person parl:personFamilyName ?familyName . }
         }
           FILTER regex(str(?familyName), \"^#{letter}\", 'i') .
-       }
-     ")
+       }"
   end
 
   def self.a_z_letters_members_current(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -300,14 +288,12 @@ class PartyQueryObject
 
           BIND(ucase(SUBSTR(?familyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ")
+      }"
   end
 
   def self.lookup_by_letters(letters)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?party
         	a parl:Party ;
          	parl:partyName ?partyName .
@@ -317,7 +303,6 @@ class PartyQueryObject
         ?party parl:partyName ?partyName .
 
     	  FILTER(regex(str(?partyName), \"#{letters}\", 'i')) .
-      }
-    ")
+      }"
   end
 end

--- a/app/models/person_query_object.rb
+++ b/app/models/person_query_object.rb
@@ -2,9 +2,8 @@ class PersonQueryObject
   extend QueryObject
 
   def self.all
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	a parl:Person ;
          	parl:personGivenName ?givenName ;
@@ -14,13 +13,12 @@ class PersonQueryObject
         ?person a parl:Person .
         OPTIONAL { ?person parl:personGivenName ?givenName } .
         OPTIONAL { ?person parl:personFamilyName ?familyName } .
-      }")
+      }"
   end
 
   def self.lookup(source, id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	a parl:Person .
       }
@@ -30,13 +28,12 @@ class PersonQueryObject
 
         ?person a parl:Person .
         ?person ?source ?id .
-      }")
+      }"
   end
 
   def self.all_by_letter(letter)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	a parl:Person ;
          	parl:personGivenName ?givenName ;
@@ -48,14 +45,12 @@ class PersonQueryObject
         OPTIONAL { ?person parl:personFamilyName ?familyName } .
 
     	  FILTER regex(str(?familyName), \"^#{letter}\", 'i') .
-      }
-    ")
+      }"
   end
 
   def self.a_z_letters
-    self.uri_builder('
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    'PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
          _:x parl:value ?firstLetter .
       }
       WHERE {
@@ -65,58 +60,57 @@ class PersonQueryObject
 
           BIND(ucase(SUBSTR(?familyName, 1, 1)) as ?firstLetter)
         }
-      }
-    ')
+      }'
   end
 
   def self.find(id)
-    self.uri_builder("
-     PREFIX parl: <http://id.ukpds.org/schema/>
-      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-      CONSTRUCT {
-          ?person a parl:Person ;
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+     CONSTRUCT {
+        ?person a parl:Person ;
               parl:personDateOfBirth ?dateOfBirth ;
               parl:personGivenName ?givenName ;
               parl:personOtherNames ?otherName ;
               parl:personFamilyName ?familyName ;
-    		      parl:personHasGenderIdentity ?genderIdentity ;
               parl:partyMemberHasPartyMembership ?partyMembership ;
               parl:memberHasIncumbency ?incumbency .
      	  ?contactPoint a parl:ContactPoint ;
         	  parl:email ?email ;
         	  parl:phoneNumber ?phoneNumber ;
-        	  parl:faxNumber ?faxNumber ;
     		    parl:contactPointHasPostalAddress ?postalAddress .
     	  ?postalAddress a parl:PostalAddress ;
-        	  parl:addressLine1 ?addressLine1 ;
-			      parl:addressLine2 ?addressLine2 ;
-        	  parl:addressLine3 ?addressLine3 ;
-        	  parl:addressLine4 ?addressLine4 ;
-        	  parl:addressLine5 ?addressLine5 ;
+            parl:addressLine1 ?addressLine1 ;
+            parl:addressLine2 ?addressLine2 ;
+            parl:addressLine3 ?addressLine3 ;
+            parl:addressLine4 ?addressLine4 ;
+            parl:addressLine5 ?addressLine5 ;
+            parl:faxNumber ?faxNumber ;
         	  parl:postCode ?postCode .
     	  ?constituency a parl:ConstituencyGroup ;
              parl:constituencyGroupName ?constituencyName .
     	  ?seatIncumbency a parl:SeatIncumbency ;
-        	  	parl:incumbencyEndDate ?incumbencyEndDate ;
-        	  	parl:incumbencyStartDate ?incumbencyStartDate ;
+        	  	parl:incumbencyEndDate ?seatIncumbencyEndDate ;
+        	  	parl:incumbencyStartDate ?seatIncumbencyStartDate ;
 				      parl:seatIncumbencyHasHouseSeat ?seat ;
         		  parl:incumbencyHasContactPoint ?contactPoint .
-    	?houseIncumbency a parl:HouseIncumbency ;
-        		parl:incumbencyEndDate ?incumbencyEndDate ;
-        	  parl:incumbencyStartDate ?incumbencyStartDate ;
-        		parl:houseIncumbencyHasHouse ?house ;
+    	  ?houseIncumbency a parl:HouseIncumbency ;
+        		parl:incumbencyEndDate ?houseIncumbencyEndDate ;
+        	  parl:incumbencyStartDate ?houseIncumbencyStartDate ;
+        		parl:houseIncumbencyHasHouse ?house1 ;
         		parl:incumbencyHasContactPoint ?contactPoint .
         ?seat a parl:HouseSeat ;
             	parl:houseSeatHasConstituencyGroup ?constituency ;
-            	parl:houseSeatHasHouse ?house .
+            	parl:houseSeatHasHouse ?house2 .
     		?party a parl:Party ;
              	parl:partyName ?partyName .
     		?partyMembership a parl:PartyMembership ;
         	  	parl:partyMembershipStartDate ?partyMembershipStartDate ;
         	  	parl:partyMembershipEndDate ?partyMembershipEndDate ;
 				      parl:partyMembershipHasParty ?party .
-    		?house a parl:House ;
-            	parl:houseName ?houseName .
+    		?house1 a parl:House ;
+            	parl:houseName ?houseName1 .
+        ?house2 a parl:House ;
+            	parl:houseName ?houseName2 .
       }
       WHERE {
         BIND(<#{DATA_URI_PREFIX}/#{id}> AS ?person)
@@ -125,52 +119,55 @@ class PersonQueryObject
         OPTIONAL { ?person parl:personFamilyName ?familyName } .
     	  OPTIONAL {
     	      ?person parl:memberHasIncumbency ?incumbency .
-            OPTIONAL { ?incumbency parl:incumbencyEndDate ?incumbencyEndDate . }
-    	      ?incumbency parl:incumbencyStartDate ?incumbencyStartDate .
-        	  {
+            OPTIONAL
+        	    {
         	      ?incumbency a parl:HouseIncumbency .
-                BIND(?incumbency AS ?houseIncumbency )
-                ?houseIncumbency parl:houseIncumbencyHasHouse ?house .
-            	  ?house parl:houseName ?houseName .
-        	  } UNION {
+                BIND(?incumbency AS ?houseIncumbency)
+                ?houseIncumbency parl:houseIncumbencyHasHouse ?house1 .
+            	  ?house1 parl:houseName ?houseName1 .
+                ?houseIncumbency parl:incumbencyStartDate ?houseIncumbencyStartDate .
+                OPTIONAL { ?houseIncumbency parl:incumbencyEndDate ?houseIncumbencyEndDate . }
+        	    }
+              OPTIONAL {
         	      ?incumbency a parl:SeatIncumbency .
-                BIND(?incumbency AS ?seatIncumbency )
+                BIND(?incumbency AS ?seatIncumbency)
                 ?seatIncumbency parl:seatIncumbencyHasHouseSeat ?seat .
             	  ?seat parl:houseSeatHasConstituencyGroup ?constituency .
-    	      	  ?seat parl:houseSeatHasHouse ?house .
-            	  ?house parl:houseName ?houseName .
+    	      	  ?seat parl:houseSeatHasHouse ?house2 .
+            	  ?house2 parl:houseName ?houseName2 .
             	  ?constituency parl:constituencyGroupName ?constituencyName .
-        	  }
-            OPTIONAL {
-        	    ?incumbency parl:incumbencyHasContactPoint ?contactPoint .
-        	    OPTIONAL { ?contactPoint parl:phoneNumber ?phoneNumber . }
-        	    OPTIONAL { ?contactPoint parl:email ?email . }
-        	    OPTIONAL { ?contactPoint parl:faxNumber ?faxNumber . }
-        	    OPTIONAL {
-        	        ?contactPoint parl:contactPointHasPostalAddress ?postalAddress .
-				          OPTIONAL { ?postalAddress parl:addressLine1 ?addressLine1 . }
-				          OPTIONAL { ?postalAddress parl:addressLine2 ?addressLine2 . }
-        	    	  OPTIONAL { ?postalAddress parl:addressLine3 ?addressLine3 . }
-        	    	  OPTIONAL { ?postalAddress parl:addressLine4 ?addressLine4 . }
-        	    	  OPTIONAL { ?postalAddress parl:addressLine5 ?addressLine5 . }
-        	    	  OPTIONAL { ?postalAddress parl:postCode ?postCode . }
+                ?seatIncumbency parl:incumbencyStartDate ?seatIncumbencyStartDate .
+                OPTIONAL { ?seatIncumbency parl:incumbencyEndDate ?seatIncumbencyEndDate . }
         	    }
-    	      }
-          } OPTIONAL {
-    	      ?person parl:partyMemberHasPartyMembership ?partyMembership .
-            ?partyMembership parl:partyMembershipHasParty ?party .
-            ?partyMembership parl:partyMembershipStartDate ?partyMembershipStartDate .
-            OPTIONAL { ?partyMembership parl:partyMembershipEndDate ?partyMembershipEndDate . }
-            ?party parl:partyName ?partyName .
-          }
-        }")
+              OPTIONAL {
+        	        ?incumbency parl:incumbencyHasContactPoint ?contactPoint .
+        	        OPTIONAL { ?contactPoint parl:phoneNumber ?phoneNumber . }
+        	        OPTIONAL { ?contactPoint parl:email ?email . }
+        	        OPTIONAL {
+        	          ?contactPoint parl:contactPointHasPostalAddress ?postalAddress .
+				            OPTIONAL { ?postalAddress parl:addressLine1 ?addressLine1 . }
+				            OPTIONAL { ?postalAddress parl:addressLine2 ?addressLine2 . }
+        	    	    OPTIONAL { ?postalAddress parl:addressLine3 ?addressLine3 . }
+        	    	    OPTIONAL { ?postalAddress parl:addressLine4 ?addressLine4 . }
+        	    	    OPTIONAL { ?postalAddress parl:addressLine5 ?addressLine5 . }
+        	    	    OPTIONAL { ?postalAddress parl:faxNumber ?faxNumber . }
+        	    	    OPTIONAL { ?postalAddress parl:postCode ?postCode . }
+        	        }
+    	          }
+            }
+            OPTIONAL {
+    	        ?person parl:partyMemberHasPartyMembership ?partyMembership .
+              ?partyMembership parl:partyMembershipHasParty ?party .
+              ?partyMembership parl:partyMembershipStartDate ?partyMembershipStartDate .
+              OPTIONAL { ?partyMembership parl:partyMembershipEndDate ?partyMembershipEndDate . }
+              ?party parl:partyName ?partyName .
+            }
+          }"
   end
 
   def self.constituencies(id)
-    self.uri_builder("
-       PREFIX parl: <http://id.ukpds.org/schema/>
-
-       CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person a parl:Person ;
               parl:personGivenName ?givenName ;
               parl:personFamilyName ?familyName .
@@ -178,15 +175,15 @@ class PersonQueryObject
         	  a parl:ConstituencyGroup ;
             parl:constituencyGroupName ?constituencyName ;
         	  parl:constituencyGroupStartDate ?constituencyStartDate ;
-        	  parl:constituencyGroupEndDate ?constituencyEndDate ;
-            parl:constituencyGroupHasHouseSeat ?seat .
+        	  parl:constituencyGroupEndDate ?constituencyEndDate .
     	  ?seat
         	  a parl:HouseSeat ;
-        	  parl:houseSeatHasSeatIncumbency ?seatIncumbency .
+        	  parl:houseSeatHasConstituencyGroup ?constituency .
     	  ?seatIncumbency
             a parl:SeatIncumbency ;
         	  parl:incumbencyEndDate ?seatIncumbencyEndDate ;
-        	  parl:incumbencyStartDate ?seatIncumbencyStartDate .
+        	  parl:incumbencyStartDate ?seatIncumbencyStartDate ;
+            parl:seatIncumbencyHasHouseSeat ?seat .
       }
       WHERE {
         BIND(<#{DATA_URI_PREFIX}/#{id}> AS ?person)
@@ -205,15 +202,12 @@ class PersonQueryObject
           ?constituency parl:constituencyGroupStartDate ?constituencyStartDate .
 		      OPTIONAL { ?constituency parl:constituencyGroupEndDate ?constituencyEndDate . }
         }
-      }
-    ")
+      }"
   end
 
   def self.current_constituency(id)
-    self.uri_builder("
-       PREFIX parl: <http://id.ukpds.org/schema/>
-
-       CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
               a parl:Person ;
               parl:personGivenName ?givenName ;
@@ -246,26 +240,23 @@ class PersonQueryObject
           ?constituency parl:constituencyGroupName ?constituencyName .
           ?constituency parl:constituencyGroupStartDate ?constituencyStartDate .
         }
-      }
-    ")
+      }"
   end
 
   def self.parties(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
     	?person a parl:Person ;
               parl:personGivenName ?givenName ;
               parl:personFamilyName ?familyName .
       ?party
         	  a parl:Party ;
-            parl:partyName ?partyName ;
-            parl:partyHasPartyMembership ?partyMembership .
+            parl:partyName ?partyName .
     	?partyMembership
             a parl:PartyMembership ;
         	  parl:partyMembershipStartDate ?partyMembershipStartDate ;
-        	  parl:partyMembershipEndDate ?partyMembershipEndDate .
+        	  parl:partyMembershipEndDate ?partyMembershipEndDate ;
+            parl:partyMembershipHasParty ?party .
        }
        WHERE {
           BIND(<#{DATA_URI_PREFIX}/#{id}> AS ?person)
@@ -280,15 +271,12 @@ class PersonQueryObject
             OPTIONAL { ?partyMembership parl:partyMembershipEndDate ?partyMembershipEndDate . }
             ?party parl:partyName ?partyName .
           }
-       }
-     ")
+       }"
   end
 
   def self.current_party(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
     	?person a parl:Person ;
               parl:personGivenName ?givenName ;
               parl:personFamilyName ?familyName .
@@ -313,14 +301,12 @@ class PersonQueryObject
             ?partyMembership parl:partyMembershipStartDate ?partyMembershipStartDate .
             ?party parl:partyName ?partyName .
     	    }
-       }
-    ")
+       }"
   end
 
   def self.contact_points(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
           a parl:Person ;
           parl:personGivenName ?givenName ;
@@ -367,35 +353,35 @@ class PersonQueryObject
         		  OPTIONAL { ?postalAddress parl:postCode ?postCode . }
         	}
         }
-      }
-    ")
+      }"
   end
 
   def self.houses(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
             a parl:Person ;
             parl:personGivenName ?givenName ;
             parl:personFamilyName ?familyName .
-    	  ?house
+    	  ?house1
             a parl:House ;
-    			  parl:houseName ?houseName ;
-            parl:houseHasHouseSeat ?houseSeat ;
-            parl:houseHasHouseIncumbency ?houseIncumbency .
+    			  parl:houseName ?houseName1 .
+        ?house2
+            a parl:House ;
+    			  parl:houseName ?houseName2 .
     	  ?seatIncumbency
-            a parl:SeatIncumbency ;
+            a parl:Incumbency ;
         	  parl:incumbencyEndDate ?incumbencyEndDate ;
-        	  parl:incumbencyStartDate ?incumbencyStartDate .
+        	  parl:incumbencyStartDate ?incumbencyStartDate ;
+            parl:seatIncumbencyHasHouseSeat ?houseSeat .
     		?houseSeat
         		a parl:HouseSeat ;
-        		parl:houseSeatHasSeatIncumbency ?seatIncumbency .
+        		parl:houseSeatHasHouse ?house1 .
     		?houseIncumbency
-        		a parl:HouseIncumbency ;
+        		a parl:Incumbency ;
         		parl:incumbencyEndDate ?incumbencyEndDate ;
         	  parl:incumbencyStartDate ?incumbencyStartDate ;
-        		parl:houseIncumbencyHasHouse ?house .
+        		parl:houseIncumbencyHasHouse ?house2 .
       }
       WHERE {
         BIND(<#{DATA_URI_PREFIX}/#{id}> AS ?person)
@@ -411,28 +397,25 @@ class PersonQueryObject
            OPTIONAL {
         	   ?incumbency a parl:HouseIncumbency .
              BIND(?incumbency AS ?houseIncumbency )
-             ?houseIncumbency parl:houseIncumbencyHasHouse ?house .
-             ?house parl:houseName ?houseName .
+             ?houseIncumbency parl:houseIncumbencyHasHouse ?house2 .
+             ?house parl:houseName ?houseName2 .
         	 }
             OPTIONAL {
         	    ?incumbency a parl:SeatIncumbency .
               BIND(?incumbency AS ?seatIncumbency )
               ?seatIncumbency parl:seatIncumbencyHasHouseSeat ?houseSeat .
             	?houseSeat parl:houseSeatHasConstituencyGroup ?constituency .
-    	      	?houseSeat parl:houseSeatHasHouse ?house .
-            	?house parl:houseName ?houseName .
+    	      	?houseSeat parl:houseSeatHasHouse ?house1 .
+            	?house parl:houseName ?houseName1 .
             	?constituency parl:constituencyGroupName ?constituencyName .
         	  }
         }
-      }
-    ")
+      }"
   end
 
   def self.current_house(id)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
             a parl:Person ;
             parl:personGivenName ?givenName ;
@@ -479,14 +462,12 @@ class PersonQueryObject
             	?constituency parl:constituencyGroupName ?constituencyName .
         	  }
         }
-      }
-    ")
+      }"
   end
 
   def self.lookup_by_letters(letters)
-    self.uri_builder("
-      PREFIX parl: <http://id.ukpds.org/schema/>
-      CONSTRUCT {
+    "PREFIX parl: <http://id.ukpds.org/schema/>
+     CONSTRUCT {
         ?person
         	a parl:Person ;
          	parl:personGivenName ?givenName ;
@@ -498,7 +479,6 @@ class PersonQueryObject
         OPTIONAL { ?person parl:personFamilyName ?familyName } .
 
     	  FILTER(regex(str(?familyName), \"#{letters}\", 'i') || regex(str(?givenName), \"#{letters}\", 'i')) .
-      }
-    ")
+      }"
   end
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -7,3 +7,4 @@ Mime::Type.register "text/turtle", :ttl
 Mime::Type.register "application/ld+json", :ldjson
 Mime::Type.register "application/rdf-xml", :rdf
 Mime::Type.register "application/n-triples", :nt
+Mime::Type.register "application/sparql-query", :sparql


### PR DESCRIPTION
- Also changed the method of calling the triple store to POST to allow for large queries.  This has meant changing all queries to just be strings rather than encoded as urls.
